### PR TITLE
docs(readme): fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Sign in with X describes how blockchain accounts can authenticate with off-chain
 
 ## Supported Networks
 
-SIWx currently supports three blockchain networks:
+SIWx currently supports the following blockchain networks:
 
 1. Ethereum (and by extension, all EIP-155 chains)
 2. Solana


### PR DESCRIPTION
"three blockchain networks" but 5 are listed, I changed the copy to decouple it from the list for easier maintenance